### PR TITLE
add: PSP save unification and DLC support

### DIFF
--- a/plus/usr/lib/python2.7/site-packages/configgen/emulatorlauncher.sh
+++ b/plus/usr/lib/python2.7/site-packages/configgen/emulatorlauncher.sh
@@ -463,6 +463,22 @@ fi
 
 ################################################################################
 
+### SONY PSP
+
+### Inclui compatibilidade a DLCs dos jogos de PSP que tem esse suporte
+if [ "$SYSTEM" == 'psp' ]; then
+   DLC="$HOME/../roms/psp/DLC"
+   STM="$HOME/../system/configs/ppsspp/PSP/SYSTEM"
+	if ! [ -d "$STM" ]; then
+	     mkdir -p "$(dirname "$STM")"
+	     ln -s "$HOME/../roms/psp/DLC" "$HOME/../system/configs/ppsspp/PSP/GAME"
+		 ln -s "$HOME/../system/configs/ppsspp/PSP" "$HOME/../saves/psp/PSP"
+		 sleep 0.5		 
+	fi
+fi
+
+#################################################################################
+
 ### LINUX
 
 if [ "$SYSTEM" == 'linux' ]; then

--- a/plus/usr/share/batocera/datainit/roms/psp/DLC/_info.plus.txt
+++ b/plus/usr/share/batocera/datainit/roms/psp/DLC/_info.plus.txt
@@ -1,0 +1,8 @@
+## SYSTEM SONY PLAYSTATION PORTABLE DLCs ##
+-------------------------------------------------------------------------------
+Place DLCs from PSP console here
+-------------------------------------------------------------------------------
+PSP DLCs can be find on the website above
+
+https://cdromance.com/sony-psp-dlc-list-psp-downloadable-content/?__cf_chl_jschl_tk__=702635c2c5f39f30c8877fb17afce1a7793a8d08-1582127604-0-AdPRPvN7Bb05Ni5hXw89jC5lPLkzOs1Y2yJW5md8Cwds933BARuAfXpgGFycJJqu11m6Aa_LTFcsBTHfjoyEcEVXs6hbq3RFvIdNJsJVpAZftUNPdm4uLPJIkfMhSSMbpVkSzBC2qrLLMC1cgyvH2nOYe7COm4gotvNmEPDxOF2uSaWDZxie30UYGxEzyvBSuVrjqef7bQTN_OIIu50QpZXpPwXngNNH0-tJ9B_uX8Ztn2QJdxTJwfrdh2i5a_qBcIQssjq9aTassbSPmfeqVCh0tRzBGNHaTgsFI_xvpXXKLfGlgvwzdJw-kvVJkM-a1lVVr1bz3CdcwJgMN2sCHXk
+-------------------------------------------------------------------------------


### PR DESCRIPTION
This mod makes possible the compatibility saves betwen retroarch core and PPSSPP emuladotr, also makes possible the usage of DLCs for games with support see the "/roms/psp/DLC/_info.plus.txt" for more information